### PR TITLE
Add CV builder image publishing workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.env
+.git
+.uv-cache
+node_modules
+dist
+latex/*.pdf
+latex/*.tex

--- a/.github/workflows/publish-cv-builder.yml
+++ b/.github/workflows/publish-cv-builder.yml
@@ -1,0 +1,74 @@
+name: Publish CV Builder Image
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - .dockerignore
+      - .github/workflows/publish-cv-builder.yml
+      - Dockerfile
+      - build.py
+      - pyproject.toml
+      - templates/**
+      - tests/test_build.py
+      - uv.lock
+  pull_request:
+    paths:
+      - .dockerignore
+      - .github/workflows/publish-cv-builder.yml
+      - Dockerfile
+      - build.py
+      - pyproject.toml
+      - templates/**
+      - tests/test_build.py
+      - uv.lock
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/dswistowski/cv-builder
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install test dependencies
+        run: python -m pip install click==8.3.2 jinja2==3.1.6 pyyaml==6.0.3
+
+      - name: Run tests
+        run: python -m unittest tests.test_build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: image-tags
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and optionally publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ steps.image-tags.outputs.short_sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir click==8.3.2 jinja2==3.1.6 pyyaml==6.0.3
+
+COPY build.py /app/build.py
+COPY templates /app/templates
+
+ENTRYPOINT ["python", "/app/build.py", "latex"]

--- a/build.py
+++ b/build.py
@@ -1,11 +1,13 @@
 
+from pathlib import Path
+
 import click
 import yaml
 from jinja2 import Environment, FileSystemLoader
 
 
 env = Environment(
-        loader=FileSystemLoader("templates"),
+        loader=FileSystemLoader(Path(__file__).resolve().parent / "templates"),
         block_start_string="««",
         block_end_string="»»",
         variable_start_string="«",
@@ -59,8 +61,24 @@ def cli():
 
 
 @cli.command()
-def latex():
-    with open("config.yaml") as config:
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=Path("config.yaml"),
+    show_default=True,
+    help="YAML config used to render the CV.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path("latex/cv.tex"),
+    show_default=True,
+    help="Path where the rendered TeX file will be written.",
+)
+def latex(config_path, output_path):
+    with config_path.open(encoding="utf-8") as config:
         config = yaml.safe_load(config)
 
     technology = config.get("technology") or {}
@@ -70,10 +88,11 @@ def latex():
         if values
     ]
 
-    click.echo("ℹ️  will generate `cv.tex`")
+    click.echo(f"will generate `{output_path}`")
     template = env.get_template("cv.tex.j2")
 
-    with open("latex/cv.tex", "w") as cv:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as cv:
         cv.write(template.render(**config))
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,54 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from click.testing import CliRunner
+
+import build
+
+
+class LatexCommandTest(unittest.TestCase):
+    def test_latex_accepts_config_and_output_paths(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.yaml"
+            output_path = tmp / "out" / "cv.tex"
+            config_path.write_text(
+                """
+---
+name: Test User
+email: test@example.com
+phone: "+44 0000"
+github: https://github.com/example
+linkedin: https://linkedin.com/in/example
+about_me:
+  - Builds reliable systems.
+core_skills:
+  - Python
+technology:
+  languages:
+    - Python
+work: []
+education: []
+publications: []
+talks: []
+interests: []
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(
+                build.cli,
+                ["latex", "--config", str(config_path), "--output", str(output_path)],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue(output_path.exists())
+            rendered = output_path.read_text(encoding="utf-8")
+            self.assertIn(r"\cvheader{Test User}", rendered)
+            self.assertIn("Python", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Parameterize the LaTeX CV builder so it can render from an arbitrary config path to an arbitrary output path.
- Add a minimal Docker image for the TeX source generator.
- Add a GitHub Actions workflow that tests/builds on PRs and publishes ghcr.io/dswistowski/cv-builder:latest plus a short-SHA tag on pushes to main.

## Verification
- UV_CACHE_DIR=.uv-cache uv run python -m unittest tests.test_build
- UV_CACHE_DIR=.uv-cache uv run python -c 'import yaml; yaml.safe_load(open(".github/workflows/publish-cv-builder.yml", encoding="utf-8")); print("workflow yaml ok")'
- git diff --check
- docker build --no-cache -t ghcr.io/dswistowski/cv-builder:ci-test .
- docker run --rm -v /Users/damian/projects/dswistowski.github.io/config.yaml:/input/config.yaml:ro -v /private/tmp/cv-builder-ci-smoke:/output ghcr.io/dswistowski/cv-builder:ci-test --config /input/config.yaml --output /output/cv.tex
- test -s /private/tmp/cv-builder-ci-smoke/cv.tex