### PR TITLE
Add CV builder image source label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.13-slim
 
+LABEL org.opencontainers.image.source="https://github.com/dswistowski/dswistowski.github.io"
+
 WORKDIR /app
 
 RUN pip install --no-cache-dir click==8.3.2 jinja2==3.1.6 pyyaml==6.0.3


### PR DESCRIPTION
## Summary
- Add the OCI source label to the CV builder image so GHCR can associate the image with this repository.
- Keeps this follow-up intentionally tiny so the package workflow can be exercised again cleanly.

## Verification
- UV_CACHE_DIR=.uv-cache uv run python -m unittest tests.test_build
- UV_CACHE_DIR=.uv-cache uv run python -c 'import yaml; yaml.safe_load(open(".github/workflows/publish-cv-builder.yml", encoding="utf-8")); print("workflow yaml ok")'
- git diff --check
- docker build -t ghcr.io/dswistowski/cv-builder:label-test .